### PR TITLE
Default summary and description to en_GB

### DIFF
--- a/addons.py
+++ b/addons.py
@@ -154,20 +154,26 @@ def extractAddonData(data):
         addon['provides'] = u""
 
     try:
-        addon['summary'] = u""+data('summary', lang="en")[0].string
+        addon['summary'] = u""+data('summary', lang="en_GB")[0].string
     except:
         try:
-            addon['summary'] = u""+data.summary.string
+            addon['summary'] = u""+data('summary', lang="en")[0].string
         except:
-            addon['summary'] = u""
+            try:
+                addon['summary'] = u""+data.summary.string
+            except:
+                addon['summary'] = u""
 
     try:
-        addon['description'] = u""+data('description', lang="en")[0].string
+        addon['description'] = u""+data('description', lang="en_GB")[0].string
     except:
         try:
-            addon['description'] = u""+data.description.string
+            addon['description'] = u""+data('description', lang="en")[0].string
         except:
-            addon['description'] = u""
+            try:
+                addon['description'] = u""+data.description.string
+            except:
+                addon['description'] = u""
 
     try:
         addon['platform'] = u""+data.platform.string


### PR DESCRIPTION
some of our addon.xml are using "en_GB" as language tags, some are using "en".
The wiki bot script only checks for "en" and falls back to using the first value, causing us to end up with Afrikaans (for instance here: http://kodi.wiki/view/Add-on:Kodi_Add-on_repository)